### PR TITLE
Add and enable custom warnings.

### DIFF
--- a/Configurations/Product/UnitTest.xcconfig
+++ b/Configurations/Product/UnitTest.xcconfig
@@ -13,3 +13,8 @@ BUNDLE_LOADER = $(TEST_HOST)
 LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @executable_path/Frameworks
 USER_HEADER_SEARCH_PATHS = $(value) $(PARSE_DIR)/Tests/**
 CLANG_ENABLE_MODULES = YES
+
+//
+// Extra warnings
+// 'auto-import' - warns when an old-style hashed import could be replaced with modular import aka @import.
+WARNING_CFLAGS = $(inherited) -Wauto-import

--- a/Configurations/Warnings.xcconfig
+++ b/Configurations/Warnings.xcconfig
@@ -41,3 +41,18 @@ CLANG_WARN_OBJC_IMPLICIT_ATOMIC_PROPERTIES = YES
 GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR
 CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR
 CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR
+
+//
+// Extra warnings, not available directly in build settings.
+// 'auto-import' - warns when an old-style hashed import could be replaced with modular import aka @import.
+// 'switch-enum' - enforces explicit handling of cases in switch statements.
+// 'method-signatures' - enforces method signatures to always match.
+// 'idiomatic-parentheses' - do not allow usage of an assignment as a condition without extra paranthesis.
+// 'covered-switch-default' - warns when implementing 'default' case in switch statement that covers all options.
+// 'custom-atomic-properties' - safeguards atomic properties with custom implementations.
+// 'cstring-format-directive' - do not allow NSString * to be used as c-string formatting argument aka '%s'.
+// 'conditional-uninitialized' - warn about potential use of of uninitialized variables.
+// 'unused-exception-parameter' - @try @catch without usage of exception parameter.
+// 'missing-variable-declarations' - will mark all variables that are missing declarations, including non-static extern constants.
+//
+WARNING_CFLAGS = $(inherited) -Wswitch-enum -Wmethod-signatures -Widiomatic-parantheses -Wcovered-switch-default -Wcustom-atomic-properties -Wcstring-format-directive -Wconditional-uninitialized -Wunused-exception-parameter -Wmissing-variable-declarations


### PR DESCRIPTION
Added a long list of custom warnings and enabled most of them for all targets.
`auto-import` isn't going to be enabled for other targets, until CocoaPods enables modules for all targets by default (both static libraries and frameworks).