### PR TITLE
Fix typo in xctask build script.

### DIFF
--- a/Scripts/xctask/build_task.rb
+++ b/Scripts/xctask/build_task.rb
@@ -36,7 +36,7 @@ module XCTask
       if action.nil? ||
          (action != BUILD &&
          action != CLEAN &&
-         action != TEST
+         action != TEST &&
          action != ANALYZE)
         fail "Unknown build action used. Available actions: 'build', 'clean', 'test', 'analyze'."
       end


### PR DESCRIPTION
(－‸ლ)