### PR TITLE
Remove not required runtime search paths from LogicTests configuration.

### DIFF
--- a/Configurations/Product/LogicTests.xcconfig
+++ b/Configurations/Product/LogicTests.xcconfig
@@ -10,5 +10,3 @@
 BUNDLE_LOADER = $(TEST_HOST)
 
 OTHER_LDFLAGS = $(inherited) -ObjC -framework XCTest
-
-LD_RUNPATH_SEARCH_PATHS = $(inherited) @loader_path/Frameworks @executable_path/Frameworks


### PR DESCRIPTION
We have it set based on per-configuration case.