### PR TITLE
Disable code signing altogether for framework targets.

### DIFF
--- a/Configurations/Product/DynamicFramework.xcconfig
+++ b/Configurations/Product/DynamicFramework.xcconfig
@@ -27,3 +27,6 @@ SKIP_INSTALL = YES
 
 // Do not require code signing
 CODE_SIGNING_REQUIRED = NO
+
+// Disable code signing
+CODE_SIGN_IDENTITY = 

--- a/Configurations/Product/StaticFramework.xcconfig
+++ b/Configurations/Product/StaticFramework.xcconfig
@@ -31,3 +31,6 @@ SKIP_INSTALL = YES
 
 // Do not require code signing
 CODE_SIGNING_REQUIRED = NO
+
+// Disable code signing
+CODE_SIGN_IDENTITY = 


### PR DESCRIPTION
This is disabled by Xcode for iOS/macOS, but is enabled for tvOS/watchOS, so disable everywhere.
The target product configuration should specify the code signing identity if code signing should be turned on.